### PR TITLE
Display welcome screen when no Spotify tokens are available on opening the app

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, vi, expect, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import App from "./App.tsx";
+import * as screensUtils from "./feat/screens/utils.ts";
+
+vi.mock("./feat/screens/WelcomeScreen.tsx", () => {
+  return {
+    default: function WelcomeScreen() {
+      return <main data-testid="welcome-screen"></main>;
+    },
+  };
+});
+
+/*
+The return value of useAccountConnectionStatus() is irrelevant here (and so made null),
+  as it is only used as an argument in getScreenName(),
+  the return value of which is mocked anyway.
+*/
+vi.mock("./feat/accountConnection/hooks.ts", () => {
+  return {
+    useAccountConnectionStatus() {
+      return null;
+    },
+  };
+});
+
+describe("The app", () => {
+  const getScreenNameSpy = vi.spyOn(screensUtils, "getScreenName");
+
+  afterEach(() => {
+    getScreenNameSpy.mockReset();
+    cleanup();
+  });
+
+  it("should be able to start with the welcome screen", () => {
+    getScreenNameSpy.mockReturnValue("welcome");
+
+    render(<App />);
+
+    const element = screen.queryByTestId("welcome-screen");
+    expect(element).not.toBeNull();
+  });
+
+  it("should be able not to start with the welcome screen", () => {
+    getScreenNameSpy.mockReturnValue("none");
+
+    render(<App />);
+
+    const element = screen.queryByTestId("welcome-screen");
+    expect(element).toBeNull();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,17 @@
+import { useAccountConnectionStatus } from "./feat/accountConnection/hooks.ts";
+import { getScreenName } from "./feat/screens/utils.ts";
+import WelcomeScreen from "./feat/screens/WelcomeScreen.tsx";
+
 function App() {
-  return <></>;
+  const accountConnectionStatus = useAccountConnectionStatus();
+  const screenName = getScreenName(accountConnectionStatus);
+
+  switch (screenName) {
+    case "welcome":
+      return <WelcomeScreen />;
+    default:
+      return <></>;
+  }
 }
 
 export default App;

--- a/src/feat/accountConnection/hooks.ts
+++ b/src/feat/accountConnection/hooks.ts
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import {
+  getAccountConnectionStatus,
+  getTokenBasedAction,
+  getTokens,
+} from "./utils.ts";
+
+export function useAccountConnectionStatus(): AccountConnectionStatus {
+  const [accountConnectionStatus] = useState<AccountConnectionStatus>(
+    getInitialAccountConnectionStatus(),
+  );
+
+  return accountConnectionStatus;
+}
+
+function getInitialAccountConnectionStatus(): AccountConnectionStatus {
+  const tokens = getTokens();
+  const action = getTokenBasedAction(tokens);
+
+  return getAccountConnectionStatus(action);
+}

--- a/src/feat/screens/WelcomeScreen.tsx
+++ b/src/feat/screens/WelcomeScreen.tsx
@@ -1,0 +1,15 @@
+function WelcomeScreen() {
+  return (
+    <main
+      className="flex h-screen flex-wrap content-center justify-center"
+      data-testid="welcome-screen"
+    >
+      <header className="h-20 text-center">
+        <h1 className="pb-4 text-4xl">Music App</h1>
+        <p>Please connect your Spotify account to proceed</p>
+      </header>
+    </main>
+  );
+}
+
+export default WelcomeScreen;

--- a/src/tests/acceptance/001_connectAccount.test.tsx
+++ b/src/tests/acceptance/001_connectAccount.test.tsx
@@ -1,0 +1,35 @@
+import { vi, describe, it, expect, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as accountConnection from "../../feat/accountConnection/utils.ts";
+import App from "../../App.tsx";
+
+describe("REQ-1: Let users connect their Spotify account", () => {
+  describe("AC-1.1: A welcome screen appears when no Spotify account is connected on opening the app", () => {
+    const getTokensSpy = vi.spyOn(accountConnection, "getTokens");
+
+    afterEach(() => {
+      getTokensSpy.mockReset();
+      cleanup();
+    });
+
+    it("renders the welcome screen if no tokens are available", () => {
+      getTokensSpy.mockReturnValue(null);
+
+      render(<App />);
+
+      const element = screen.queryByTestId("welcome-screen");
+      expect(element).not.toBeNull();
+    });
+
+    it("contains clear messaging prompting users to connect their Spotify account", () => {
+      getTokensSpy.mockReturnValue(null);
+
+      render(<App />);
+
+      const element = screen.queryByText(
+        "Please connect your Spotify account to proceed",
+      );
+      expect(element).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Resolves #6 

## What was done?

- Implemented a welcome screen that appears when the app is opened and no Spotify account is connected.
- Developed logic to check for a connected Spotify account on app launch.
- Ensured the welcome screen displays clear messaging prompting the user to connect their Spotify account.

## What is the purpose?

The purpose of this feature is to provide a user-friendly experience when the app is opened without a connected Spotify account. It introduces the user to the app and informs them that they need to connect their Spotify account before proceeding.

## What approach was taken?

- Introduced logic to check the account connection status. If no account is connected, the welcome screen is displayed.
- Implemented a mechanism in `App.tsx` to conditionally render screens based on the connection status by utilizing a utility that determines the appropriate screen.
- Created the welcome screen component with a minimalist design, providing clear messaging about connecting a Spotify account.
- By utilizing hooks and utility functions, kept the business logic separate from UI components, ensuring maintainability and testability.

## How is it tested?

The tests provide coverage for both the logic behind screen rendering and the user experience when interacting with the app without a connected account.
- Created an acceptance test to verify that the welcome screen appears if no tokens (representing a connected Spotify account) are available.
- Added unit tests to check the correct rendering of the welcome screen depending on the connection status.