### PR TITLE
Notify the user if connecting to the Spotify account fails

### DIFF
--- a/src/feat/screens/utils.test.ts
+++ b/src/feat/screens/utils.test.ts
@@ -10,8 +10,8 @@ describe("getDisplayedMessage()", () => {
     expect(getDisplayedMessage("unauthorized")).toBe("Not authorized.");
   });
 
-  it("returns an empty string for 'failed'", () => {
-    expect(getDisplayedMessage("failed")).toBe("");
+  it("returns 'Connection failed.' string for 'failed'", () => {
+    expect(getDisplayedMessage("failed")).toBe("Connection failed.");
   });
 
   it("returns an empty string for 'closed'", () => {

--- a/src/feat/screens/utils.ts
+++ b/src/feat/screens/utils.ts
@@ -5,6 +5,7 @@ export function getDisplayedMessage(status: AccountConnectionStatus): string {
     case "unauthorized":
       return "Not authorized.";
     case "failed":
+      return "Connection failed.";
     case "closed":
     case "initiated":
     case "validated":

--- a/src/tests/acceptance/req-1_connectAccount.test.tsx
+++ b/src/tests/acceptance/req-1_connectAccount.test.tsx
@@ -7,6 +7,7 @@ import * as tokens from "../../feat/accountConnection/utils/tokens";
 import * as handlers from "../../feat/accountConnection/handlers";
 import * as actions from "../../feat/accountConnection/utils/actions";
 import * as connectionStatus from "../../feat/accountConnection/utils/connectionStatus";
+import * as screensUtils from "../../feat/screens/utils";
 import App from "../../App";
 import { Root } from "react-dom/client";
 import { authCodeMock, authErrorParamsMock } from "../mocks/auth";
@@ -182,6 +183,56 @@ describe("REQ-1: Let users connect their Spotify account", () => {
       expect(connectionProgressScreen).toBeInTheDocument();
 
       cleanup();
+    });
+  });
+
+  describe("AC-1.6: The user is notified if connecting to the Spotify account fails", () => {
+    let getScreenNameSpy: MockInstance;
+    let getDisplayedMessageSpy: MockInstance;
+
+    beforeEach(() => {
+      getScreenNameSpy = vi
+        .spyOn(screensUtils, "getScreenName")
+        .mockReturnValue("welcome");
+
+      getDisplayedMessageSpy = vi
+        .spyOn(screensUtils, "getDisplayedMessage")
+        .mockReturnValue("Connection failed.");
+    });
+
+    afterEach(() => {
+      getScreenNameSpy.mockRestore();
+      getDisplayedMessageSpy.mockRestore();
+
+      cleanup();
+    });
+
+    it("displays a message to the user, indicating that account connection failed", () => {
+      render(<App authResponse={authCodeMock} />);
+
+      const messageBox = screen.queryByTestId(
+        "spotify-account-connection-message-box",
+      );
+      const messageText = screen.queryByTestId(
+        "spotify-account-connection-message-text",
+      );
+
+      expect(messageBox).toBeVisible();
+      expect(messageText).toBeVisible();
+    });
+
+    it("provides guidance on how the user can try to connect their Spotify account again", () => {
+      render(<App authResponse={authCodeMock} />);
+
+      const element = screen.queryByText(
+        "Please connect your Spotify account to proceed.",
+      );
+      const button = screen.getByRole("button", {
+        name: "Connect",
+      });
+
+      expect(element).toBeInTheDocument();
+      expect(button).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Resolves #11 

## What was done?

Implemented functionality to notify the user when the connection to their Spotify account fails.

## What is the purpose?

The purpose of this implementation is to ensure that users are informed when the Spotify account connection fails, enabling them to understand the issue and guiding them on how to resolve it. This enhances the overall user experience by promoting transparency and providing actionable next steps.

## What approach was taken?

Modified `getDisplayedMessage()` to return a specific message when the account connection fails.

## How is it tested?

The new functionality is tested through acceptance tests which verify:
- The visibility of the connection failure message when the connection fails.
- The presence of guidance that prompts the user to reconnect their Spotify account.

This ensures that the user experience remains informative and supportive even when issues arise.