### PR TITLE
Show main screen after successful Spotify account connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "music-app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "music-app",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "music-app",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "format": "prettier --write .",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import useAccountConnectionStatus from "./feat/accountConnection/useAccountConnectionStatus";
 import ConnectionProgress from "./feat/screens/ConnectionProgress";
+import MainScreen from "./feat/screens/MainScreen";
 import { getDisplayedMessage, getScreenName } from "./feat/screens/utils";
 import WelcomeScreen from "./feat/screens/WelcomeScreen";
 
@@ -24,6 +25,8 @@ function App({ authResponse }: Props) {
           authCode={authResponse as string}
         />
       );
+    case "main":
+      return <MainScreen displayedMessage={displayedMessage} />;
     default:
       return <></>;
   }

--- a/src/feat/screens/MainScreen.test.tsx
+++ b/src/feat/screens/MainScreen.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import "@testing-library/jest-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import MainScreen from "./MainScreen";
+
+describe("Main screen", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("Account connection message area", () => {
+    it("is not rendered if message is empty", () => {
+      render(<MainScreen displayedMessage="" />);
+
+      const messageBox = screen.queryByTestId(
+        "spotify-account-connection-message-box",
+      );
+      const messageText = screen.queryByTestId(
+        "spotify-account-connection-message-text",
+      );
+
+      expect(messageBox).not.toBeInTheDocument();
+      expect(messageText).not.toBeInTheDocument();
+    });
+
+    it("is visible to the user if there is a message to display", () => {
+      render(<MainScreen displayedMessage="Mock message." />);
+
+      const messageBox = screen.queryByTestId(
+        "spotify-account-connection-message-box",
+      );
+      const messageText = screen.queryByTestId(
+        "spotify-account-connection-message-text",
+      );
+
+      expect(messageBox).toBeVisible();
+      expect(messageText).toBeVisible();
+    });
+  });
+});

--- a/src/feat/screens/MainScreen.tsx
+++ b/src/feat/screens/MainScreen.tsx
@@ -1,0 +1,28 @@
+import CheckCircleIcon from "../../icons/CheckCircleIcon";
+
+interface Props {
+  displayedMessage?: string;
+}
+
+export default function MainScreen({ displayedMessage }: Props) {
+  return (
+    <main
+      className="flex h-screen flex-wrap content-center justify-center bg-spotify-black"
+      data-testid="main-screen"
+    >
+      {displayedMessage ? (
+        <div
+          className="mb-5 flex items-center justify-center bg-spotify-green py-3 pl-3 pr-4 text-spotify-black-text"
+          data-testid="spotify-account-connection-message-box"
+        >
+          <CheckCircleIcon htmlClasses={"mr-3 size-6 shrink-0"} />
+          <p data-testid="spotify-account-connection-message-text">
+            {displayedMessage}
+          </p>
+        </div>
+      ) : (
+        <></>
+      )}
+    </main>
+  );
+}

--- a/src/feat/screens/utils.test.ts
+++ b/src/feat/screens/utils.test.ts
@@ -30,8 +30,8 @@ describe("getDisplayedMessage()", () => {
     expect(getDisplayedMessage("pending")).toBe("");
   });
 
-  it("returns an empty string for 'ok'", () => {
-    expect(getDisplayedMessage("ok")).toBe("");
+  it("returns 'Successfully connected' string for 'ok'", () => {
+    expect(getDisplayedMessage("ok")).toBe("Successfully connected");
   });
 
   it("returns an empty string for 'updating'", () => {

--- a/src/feat/screens/utils.ts
+++ b/src/feat/screens/utils.ts
@@ -11,7 +11,9 @@ export function getDisplayedMessage(status: AccountConnectionStatus): string {
     case "validated":
     case "authorized":
     case "pending":
+      return "";
     case "ok":
+      return "Successfully connected";
     case "updating":
     case "broken":
       return "";

--- a/src/icons/CheckCircleIcon.tsx
+++ b/src/icons/CheckCircleIcon.tsx
@@ -1,0 +1,18 @@
+export default function CheckCircleIcon({ htmlClasses }: IconComponentProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={htmlClasses}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+      />
+    </svg>
+  );
+}

--- a/src/tests/acceptance/req-1_connectAccount.test.tsx
+++ b/src/tests/acceptance/req-1_connectAccount.test.tsx
@@ -225,4 +225,40 @@ describe("REQ-1: Let users connect their Spotify account", () => {
       expect(button).toBeInTheDocument();
     });
   });
+
+  describe("AC-1.7: The main screen appears after a successful Spotify account connection", () => {
+    let getScreenNameSpy: MockInstance;
+    let getDisplayedMessageSpy: MockInstance;
+
+    beforeEach(() => {
+      getScreenNameSpy = vi
+        .spyOn(screensUtils, "getScreenName")
+        .mockReturnValue("main");
+
+      getDisplayedMessageSpy = vi
+        .spyOn(screensUtils, "getDisplayedMessage")
+        .mockReturnValue("Successfully connected");
+    });
+
+    afterEach(() => {
+      getScreenNameSpy.mockRestore();
+      getDisplayedMessageSpy.mockRestore();
+
+      cleanup();
+    });
+
+    it("renders the main screen after receiveing user's Spotify profile data", () => {
+      render(<App authResponse={authCodeMock} />);
+
+      const mainScreen = screen.queryByTestId("main-screen");
+      expect(mainScreen).toBeInTheDocument();
+    });
+
+    it("contains clear indicators that the account has been successfully connected", () => {
+      render(<App authResponse={authCodeMock} />);
+
+      const message = screen.queryByText("Successfully connected");
+      expect(message).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Resolves #12 

## What was done?

- Implemented functionality to transition the app to the main screen after a successful Spotify account connection.
- Added detection for the successful completion of the Spotify authorization flow and automatic redirection to the main screen.
- Created `MainScreen` component with an optional message display, showing a success indicator upon connection.
- Updated `getDisplayedMessage()` to ensure that users receive clear feedback on the success of their account connection.
- Bumped the app version to `0.0.3`.

## What is the purpose?

The purpose is to enhance user experience by providing a smooth transition to the main screen, reinforcing the responsiveness of the application and enabling immediate access to core features after connecting their Spotify account.

## What approach was taken?

- Updated the `App` component to detect when the user’s Spotify connection is successful, transitioning the user to the `MainScreen` component.
- Developed the `MainScreen` component with a visible success message box, which includes a `CheckCircleIcon` for visual clarity. The message only appears if there’s a connection confirmation.

## How is it tested?

Introduced unit tests for `MainScreen` to confirm the success message’s visibility under different conditions and acceptance tests for AC-1.7 to validate the screen transition and success indicators.